### PR TITLE
Relax the upper-bound restriction on base

### DIFF
--- a/pidfile.cabal
+++ b/pidfile.cabal
@@ -28,7 +28,7 @@ library
   exposed-modules:     System.PidFile
   -- other-modules:       
   -- other-extensions:    
-  build-depends:       base >=4.9 && <4.12,
+  build-depends:       base >=4.9 && <5,
                        unix >=2.7 && <2.8
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
This just bumps the restriction so things will build with ghc-8.6.x. I'm also interested in getting this on stackage since that's what I'm using at work, but this, or a similar change, would be needed in a released version first. 